### PR TITLE
complete scenarios of BIM 360 documents/views

### DIFF
--- a/public/js/ForgeTree.js
+++ b/public/js/ForgeTree.js
@@ -1,22 +1,4 @@
-﻿/////////////////////////////////////////////////////////////////////
-// Copyright (c) Autodesk, Inc. All rights reserved
-// Written by Forge Partner Development
-//
-// Permission to use, copy, modify, and distribute this software in
-// object code form for any purpose and without fee is hereby granted,
-// provided that the above copyright notice appears in all copies and
-// that both that copyright notice and the limited warranty and
-// restricted rights notice below appear in all supporting
-// documentation.
-//
-// AUTODESK PROVIDES THIS PROGRAM "AS IS" AND WITH ALL FAULTS.
-// AUTODESK SPECIFICALLY DISCLAIMS ANY IMPLIED WARRANTY OF
-// MERCHANTABILITY OR FITNESS FOR A PARTICULAR USE.  AUTODESK, INC.
-// DOES NOT WARRANT THAT THE OPERATION OF THE PROGRAM WILL BE
-// UNINTERRUPTED OR ERROR FREE.
-/////////////////////////////////////////////////////////////////////
-
-$(document).ready(function () {
+﻿$(document).ready(function () {
   // first, check if current visitor is signed in
   jQuery.ajax({
     url: '/api/forge/oauth/token',
@@ -60,7 +42,7 @@ function prepareUserHubsTree() {
   $('#userHubs').jstree({
     'core': {
       'themes': { "icons": true },
-      'multiple': false,
+      'multiple': true,
       'data': {
         "url": '/api/forge/datamanagement',
         "dataType": "json",
@@ -81,9 +63,10 @@ function prepareUserHubsTree() {
       'a360projects': { 'icon': 'https://github.com/Autodesk-Forge/bim360appstore-data.management-nodejs-transfer.storage/raw/master/www/img/a360project.png' },      
       'folders': { 'icon': 'glyphicon glyphicon-folder-open' },
       'items': { 'icon': 'glyphicon glyphicon-file' },
-      'bim360documents': { 'icon': 'glyphicon glyphicon-file' },
+      'bim360documents': { 'icon': 'glyphicon glyphicon-record' },
       'versions': { 'icon': 'glyphicon glyphicon-time' },
-      'unsupported': { 'icon': 'glyphicon glyphicon-ban-circle' }
+      'views': { 'icon': 'glyphicon glyphicon-eye-open' },
+      'unsupported': { 'icon': 'glyphicon glyphicon-question-sign' }
     },
     "sort": function (a, b) {
       var a1 = this.get_node(a);
@@ -100,17 +83,26 @@ function prepareUserHubsTree() {
     "plugins": ["types", "state", "sort"],
     "state": { "key": "autodeskHubs" }// key restore tree state
   }).bind("activate_node.jstree", function (evt, data) {
-    if (data != null && data.node != null && (data.node.type == 'versions' || data.node.type == 'bim360documents')) {
-      // in case the node.id contains a | then split into URN & viewableId
-      if (data.node.id.indexOf('|') > -1) {
-        var urn = data.node.id.split('|')[1];
-        var viewableId = data.node.id.split('|')[2];
-        launchViewer(urn, viewableId);
-      }
-      else {
-        launchViewer(data.node.id);
-      }
-    }
+
+    // will launch viewer for two scenarios below:
+    // #1: version (without specifying view id, i.e. using default geometry)
+    // #2: specific view (such as document in Plan folder, or view of model version in non-Plan folder)
+
+    if (data && data.node){
+       if(data.node.type == 'bim360documents' || data.node.type == 'views' ){
+        //the format of the id will be <version urn> | < guid of this specific graphics view>
+        const params = data.node.id.split('|');
+        const urn = params[0];
+        const viewableId = params[1];
+        launchViewer(urn, viewableId); 
+       }else if(data.node.type == 'versions'){
+          //the format of the id will be <version urn>
+          const urn = data.node.id
+          launchViewer(urn);  
+       }else{
+         //unsupported type
+       }
+    } 
   });
 }
 

--- a/routes/datamanagement.js
+++ b/routes/datamanagement.js
@@ -1,23 +1,5 @@
-/////////////////////////////////////////////////////////////////////
-// Copyright (c) Autodesk, Inc. All rights reserved
-// Written by Forge Partner Development
-//
-// Permission to use, copy, modify, and distribute this software in
-// object code form for any purpose and without fee is hereby granted,
-// provided that the above copyright notice appears in all copies and
-// that both that copyright notice and the limited warranty and
-// restricted rights notice below appear in all supporting
-// documentation.
-//
-// AUTODESK PROVIDES THIS PROGRAM "AS IS" AND WITH ALL FAULTS.
-// AUTODESK SPECIFICALLY DISCLAIMS ANY IMPLIED WARRANTY OF
-// MERCHANTABILITY OR FITNESS FOR A PARTICULAR USE.  AUTODESK, INC.
-// DOES NOT WARRANT THAT THE OPERATION OF THE PROGRAM WILL BE
-// UNINTERRUPTED OR ERROR FREE.
-/////////////////////////////////////////////////////////////////////
-
 const express = require('express');
-const { HubsApi, ProjectsApi, FoldersApi, ItemsApi } = require('forge-apis');
+const { HubsApi, ProjectsApi, FoldersApi, ItemsApi,VersionsApi,DerivativesApi } = require('forge-apis');
 
 const { OAuth } = require('./common/oauth');
 
@@ -40,8 +22,16 @@ router.get('/datamanagement', async (req, res) => {
     } else {
         // Otherwise let's break it by '/'
         const params = href.split('/');
-        const resourceName = params[params.length - 2];
-        const resourceId = params[params.length - 1];
+
+        let resourceName = ''
+        let resourceId = ''
+        if(params.length>1){
+            resourceName = params[params.length - 2];
+            resourceId = params[params.length - 1];
+        }else{
+            resourceName = 'views'
+        } 
+ 
         switch (resourceName) {
             case 'hubs':
                 getProjects(resourceId, oauth.getClient(), internalToken, res);
@@ -57,10 +47,15 @@ router.get('/datamanagement', async (req, res) => {
                     getFolderContents(projectId, resourceId/*folder_id*/, oauth.getClient(), internalToken, res);
                     break;
                 }
-            case 'items':
+            case 'items': //this can be an item in non-Plan folder and can also be a bim360 document in Plan folder
                 {
                     const projectId = params[params.length - 3];
                     getVersions(projectId, resourceId/*item_id*/, oauth.getClient(), internalToken, res);
+                    break;
+                }
+            case 'views':
+                {
+                    getVersionViews(href,/*urn_id*/ oauth.getClient(), internalToken, res);
                     break;
                 }
         }
@@ -149,17 +144,108 @@ async function getFolderContents(projectId, folderId, oauthClient, credentials, 
 async function getVersions(projectId, itemId, oauthClient, credentials, res) {
     const items = new ItemsApi();
     const versions = await items.getItemVersions(projectId, itemId, {}, oauthClient, credentials);
-    res.json(versions.body.data.map((version) => {
+
+    const version_promises = versions.body.data.map(async (version) => {
         const dateFormated = new Date(version.attributes.lastModifiedTime).toLocaleString();
         const versionst = version.id.match(/^(.*)\?version=(\d+)$/)[2];
-        const viewerUrn = (version.relationships != null && version.relationships.derivatives != null ? version.relationships.derivatives.data.id : null);
+        if(version.attributes.extension.data && version.attributes.extension.data.viewableGuid){
+
+            //this might be the documents in BIM 360 Plan folder. It is view (derivative)already.
+            const viewableGuid = version.attributes.extension.data.viewableGuid 
+            //NOTE: version.id is the urn of view version, instead of the [seed file version urn]
+            //tricky to find [seed file version urn]
+            //var viewerUrn = Buffer.from(params[0]).toString('base64') + '_' + Buffer.from(params[1]).toString('base64')
+            
+            const seedVersionUrn = await getVersionRef(projectId,version.id,oauthClient, credentials) 
+            const viewerUrn = seedVersionUrn?Buffer.from(seedVersionUrn).toString('base64').replace('/', '_').trim('=').split('=').join(''):null
+             
+            return createTreeNode(
+                viewerUrn +'|' + viewableGuid,
+                decodeURI('v' + versionst + ': ' + dateFormated + ' by ' + version.attributes.lastModifiedUserName),
+                (viewerUrn != null ? 'bim360documents' : 'unsupported'),
+                false
+            ); 
+        }else{
+            //non-BIM 360 Plan folder (also Autodesk 360, Fusion 360 etc). will need to dump views in the next iteration 
+            const viewerUrn = (version.relationships != null && version.relationships.derivatives != null ? version.relationships.derivatives.data.id : null);
+            return createTreeNode(
+                viewerUrn,
+                decodeURI('v' + versionst + ': ' + dateFormated + ' by ' + version.attributes.lastModifiedUserName),
+                viewerUrn? 'versions' : 'unsupported',
+                true
+            ); 
+        } 
+    })
+    const versions_json = await Promise.all(version_promises); 
+    res.json(versions_json);
+}
+
+
+// get references of this version urn,e.g. views of seed file
+async function getVersionRef(projectId,viewUrnId, oauthClient,credentials) { 
+    // Documents in BIM 360 Folder will go to this branch
+    const versionApi = new VersionsApi()
+    const relationshipRefs = await versionApi.getVersionRelationshipsRefs(projectId,viewUrnId,{},oauthClient,credentials)
+    
+    if(relationshipRefs.body && relationshipRefs.body.data && relationshipRefs.body.data.length>0)
+    {
+        //find meta of the reference
+        const ref = relationshipRefs.body.data.find(d=>d.meta && 
+                                                        d.meta.fromType == 'versions' && 
+                                                        d.meta.toType == 'versions')
+        if(ref){
+            if(ref.meta.extension.type == 'derived:autodesk.bim360:CopyDocument'){
+                //this is a copy document, ref.id is the view urn, instead of version urn
+                //recurse until find the source version urn
+                const sourceViewId = ref.id
+                return await getVersionRef(projectId,sourceViewId, oauthClient,credentials)
+            }else if(ref.meta.extension.type == 'derived:autodesk.bim360:FileToDocument'){
+                //this is the original documents, when source model version is extracted in BIM 360 Plan folder
+                return ref.id
+            }else{
+                return null
+            }
+        }else{
+            return null
+        }
+    }else{
+        return null
+    } 
+}
+
+
+async function getVersionViews(urn, oauthClient, credentials, res) {
+
+    const derivativesApi = new DerivativesApi();
+
+    //get manifest of this model version 
+    const manifest = await derivativesApi.getManifest(urn,{},oauthClient, credentials)
+    //find the derivative of svf
+    const geo_derivatives = manifest.body.derivatives.find(d=>d.outputType == 'svf')
+
+    //get metadata of this model version
+    const metadata = await derivativesApi.getMetadata(urn,{},oauthClient, credentials); 
+
+    //dump each metadata
+    const view_promises = metadata.body.data.metadata.map(async (view) => {
+
+        //view.guid is the metadata id, now find the corresponding real vieweable id 
+
+        //search which [geometry derivative] whose [graphics] child has the same metadata id 
+        const metadata_graphics = geo_derivatives.children.find(d=>d.type == 'geometry' && 
+                                                           d.children.find(r=>r.guid == view.guid)!=null)
+        
         return createTreeNode(
-            viewerUrn,
-            decodeURI('v' + versionst + ': ' + dateFormated + ' by ' + version.attributes.lastModifiedUserName),
-            (viewerUrn != null ? 'versions' : 'unsupported'),
+            urn +'|' + (metadata_graphics?metadata_graphics.guid:'none'),
+            view.name,
+            metadata_graphics?'views':'unsupported',
             false
-        );
-    }));
+        ); 
+    }); 
+
+    //promise the iteration
+    const views_json = await Promise.all(view_promises); 
+    res.json(views_json) 
 }
 
 // Format data for tree
@@ -168,3 +254,4 @@ function createTreeNode(_id, _text, _type, _children) {
 }
 
 module.exports = router;
+


### PR DESCRIPTION
use getVersionRelationshipsRefs to find source version urn of a document view in Plan folder, including orignal extracted document and copy document

use getManifest and getMetadata to find graphics guid of a view in non-Plan folder

update the workflow of launch viewer to open version, or open view/document.